### PR TITLE
Add option to specifiy number of threads use for crawling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,25 +1,36 @@
 # Crawl
 
-Crawl pages witin a domain, reporting any page that returns a bad response code
+Crawl pages within a domain, reporting any page that returns a bad response code
 
 Usage:
 
     > crawl [options] domain
 
+    Usage: crawl [options] domain
     -s, --start /home,/about         Starting path(s), defaults to /
     -u, --username username          Basic auth username
     -p, --password password          Basic auth password
+    -c, --connections count          Max mumber of parallel connections to use. The default is 20.
     -v, --verbose                    Give details when crawling
-    -m, --markup                     Validate markup
     -h, --help                       Show this message
+        --version                    Print version
+
+
 
 Example:
 
-    > crawl http://alphasights.com --start=/no-such-page --verbose
+    > crawl https://engineering.alphasights.com --connections=5 --start=/ --verbose
 
-      Adding /no-such-page
-    Fetching /no-such-page ...
+      Adding /
+    Fetching / ...
+      Adding /positions/ruby-developer
+      Adding /positions/js-ember-developer
+      Adding /positions/ux-ui-designer
+      Adding /positions/support-specialist
+    Fetching /positions/ruby-developer
+    Fetching /positions/js-ember-developer ...
+    Fetching /positions/ux-ui-designer ...
+    Fetching /positions/support-specialist ...
 
-    Pages with errors:
-    /no-such-page found on the command line - Status code: 404
+    5 pages crawled without errors.
 

--- a/bin/crawl
+++ b/bin/crawl
@@ -2,13 +2,15 @@
 require 'optparse'
 require_relative '../lib/crawl.rb'
 
+EM.threadpool_size = 5
+
 options = {}
 optparse = OptionParser.new do |opts|
   opts.banner = "Crawl pages witin a domain, reporting any page that returns a bad response code\nUsage: crawl [options] domain"
   opts.on('-s', '--start /home,/about', Array, 'Starting path(s), defaults to /') { |o| options[:start] = o }
   opts.on('-u', '--username username', String, 'Basic auth username') { |o| options[:username] = o }
   opts.on('-p', '--password password', String, 'Basic auth password') { |o| options[:password] = o }
-  opts.on('-c', '--connections count', Integer, 'Max mumber of parallel connections to use. The default is 20.') { |o| EM.threadpool_size = o }
+  opts.on('-c', '--connections count', Integer, "Max mumber of parallel connections to use. The default is #{EM.threadpool_size}.") { |o| EM.threadpool_size = o }
   opts.on('-v', '--verbose', 'Give details when crawling') { |o| $verbose = o }
   opts.on_tail("-h", "--help", "Show this message") { |o| puts opts; exit }
   opts.on_tail("-v", "--version", "Print version") { |o| puts Crawl::VERSION; exit }

--- a/bin/crawl
+++ b/bin/crawl
@@ -8,6 +8,7 @@ optparse = OptionParser.new do |opts|
   opts.on('-s', '--start /home,/about', Array, 'Starting path(s), defaults to /') { |o| options[:start] = o }
   opts.on('-u', '--username username', String, 'Basic auth username') { |o| options[:username] = o }
   opts.on('-p', '--password password', String, 'Basic auth password') { |o| options[:password] = o }
+  opts.on('-c', '--connections count', Integer, 'Max mumber of parallel connections to use. The default is 20.') { |o| EM.threadpool_size = o }
   opts.on('-v', '--verbose', 'Give details when crawling') { |o| $verbose = o }
   opts.on_tail("-h", "--help", "Show this message") { |o| puts opts; exit }
   opts.on_tail("-v", "--version", "Print version") { |o| puts Crawl::VERSION; exit }


### PR DESCRIPTION
Simply setting `EventMachine.threadpool_size` seems to do the trick. Fun fact: If you set it to 0, it never does anything. 

```bash
Crawl pages witin a domain, reporting any page that returns a bad response code
Usage: crawl [options] domain
    -s, --start /home,/about         Starting path(s), defaults to /
    -u, --username username          Basic auth username
    -p, --password password          Basic auth password
    -c, --connections count          Max mumber of parallel connections to use. The default is 20.
    -v, --verbose                    Give details when crawling
    -h, --help                       Show this message
        --version                    Print version
```