### PR TITLE
append relative links to their source

### DIFF
--- a/lib/crawl/engine.rb
+++ b/lib/crawl/engine.rb
@@ -58,8 +58,11 @@ private
 
   def retrieve(page)
     puts "Fetching #{page.url} ..." if $verbose
-
-    full_url = options[:domain] + page.url
+    if page.url.start_with?('/')
+      full_url = options[:domain] + page.url
+    else
+      full_url = options[:domain] + page.source + '/' + page.url
+    end
 
     http = EventMachine::HttpRequest.new(full_url)
     req = http.get :redirects => MAX_REDIRECTS, :head => {'authorization' => [options[:username], options[:password]]}


### PR DESCRIPTION
While scraping a page, let's call it `"http://localhost:3000/path1/path2"`, crawl found `<a href="../../path3/path4"></a>`. When it was then time to retrieve that page, the engine raised an exception because line 63 set `full_url = "localhost:3000../../path3/path4"`. 

So I added a check: if the url is relative (does not begin with "/") then we append it to the source (with a "/" in between. So in my example above, it is now the case that `full_url = "localhost:3000/path1/path2/../../path3/path4"`.