### PR TITLE
Adds tel: protocol to ignore list

### DIFF
--- a/lib/crawl/engine.rb
+++ b/lib/crawl/engine.rb
@@ -9,7 +9,7 @@ class Crawl::Engine
                      :session_id => false}
 
 
-  IGNORE = [/#/, /mailto:/, /skype:/, /logout/, /javascript:/, %r(/xhr/), /https:/, /\.pdf$/, /^$/]
+  IGNORE = [/#/, /mailto:/, /skype:/, /logout/, /javascript:/, %r(/xhr/), /https:/, /\.pdf$/, /^$/, /tel:/]
   VALID_RESPONSE_CODES = [200, 302]
   MAX_REDIRECTS = 3
   LINE_WIDTH = 78


### PR DESCRIPTION
## What's Up

We want our system to be better integrated with softphone tech in order to more easily facilitate phone calls. 

[PR # 3522 in Pistachio](https://github.com/alphasights/pistachio/pull/3522) is trying to add this functionality but the build is not passing because Crawler is attempting to execute tel: links and ensure they are not broken.

## What This Does

This PR adds the tel: protocol to the blacklist in crawler so as to ignore links in our applications that contain links which prompt softphone applications to initiate phone calls.

## How To Review

Testing this PR would require it to be live to ensure that CircleCI correctly bypasses tel: links. As such, I was unable to directly test the impact of this change - when reviewing this, please alert me to any potential side effects of this addition.