### PR TITLE
Rely on Ruby's URI library to do the heavy lifting

### DIFF
--- a/lib/crawl/engine.rb
+++ b/lib/crawl/engine.rb
@@ -21,7 +21,7 @@ class Crawl::Engine
     @authorization = Base64.encode64("#{options[:username]}:#{options[:password]}")
     @register = Crawl::Register.new
 
-    start_pages = options[:start].to_a.map{|page| Page.new(@register, page, 'the command line')}
+    start_pages = options[:start].to_a.map{|page| Page.new(@register, page, '/')}
 
     @register.add(start_pages)
   end

--- a/lib/crawl/page.rb
+++ b/lib/crawl/page.rb
@@ -1,3 +1,5 @@
+require 'uri'
+
 class Page
   include Comparable
 
@@ -14,27 +16,19 @@ class Page
   end
 
   def relative_url
-    if url.start_with?('/')
-      url
-    else
-      "#{source_directory}/#{url}"
-    end
-  end
-
-  def source_directory
-    File.split(source).first.sub(/^\./, '').sub(/\/$/, '')
+    @relative_url ||= URI.join('http://example.com', source, url).path
   end
 
   def <=>(other)
-    url <=> other.url
+    relative_url <=> other.relative_url
   end
 
   def eql?(other)
-    url.eql?(other.url)
+    relative_url.eql?(other.relative_url)
   end
 
   def hash
-    url.hash
+    relative_url.hash
   end
 
   def success

--- a/spec/page_spec.rb
+++ b/spec/page_spec.rb
@@ -3,9 +3,11 @@ require './lib/crawl/page'
 RSpec.describe Page do
   describe "#relative_url" do
     specify { expect(Page.new(:register, "/", "/").relative_url).to eq "/" }
+    specify { expect(Page.new(:register, "./", "/").relative_url).to eq "/" }
     specify { expect(Page.new(:register, "page.html", "").relative_url).to eq "/page.html" }
     specify { expect(Page.new(:register, "/interview", "/").relative_url).to eq "/interview" }
     specify { expect(Page.new(:register, "overview.html", "/").relative_url).to eq "/overview.html" }
     specify { expect(Page.new(:register, "post-5.html", "/posts/index.html").relative_url).to eq "/posts/post-5.html" }
+    specify { expect(Page.new(:register, "https://staging.alphasights.com/careers/meet-us", "/posts/foo").relative_url).to eq "/careers/meet-us" }
   end
 end


### PR DESCRIPTION
`URI.join` doesn't work for relative URLs so we use a dummy absolute one