### PR TITLE
Support JWT authentication as well as basic auth

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,3 +10,8 @@ end
 group :test do
   gem 'rspec_junit_formatter'
 end
+
+group :development, :test do
+  gem 'pry'
+  gem 'webmock'
+end

--- a/bin/crawl
+++ b/bin/crawl
@@ -10,6 +10,7 @@ optparse = OptionParser.new do |opts|
   opts.on('-s', '--start /home,/about', Array, 'Starting path(s), defaults to /') { |o| options[:start] = o }
   opts.on('-u', '--username username', String, 'Basic auth username') { |o| options[:username] = o }
   opts.on('-p', '--password password', String, 'Basic auth password') { |o| options[:password] = o }
+  opts.on('-t', '--token token', String, 'Value of the "Authorization" header') { |o| options[:password] = o }
   opts.on('-c', '--connections count', Integer, "Max mumber of parallel connections to use. The default is #{EM.threadpool_size}.") { |o| EM.threadpool_size = o }
   opts.on('-v', '--verbose', 'Give details when crawling') { |o| $verbose = o }
   opts.on_tail("-h", "--help", "Show this message") { |o| puts opts; exit }

--- a/lib/crawl/page.rb
+++ b/lib/crawl/page.rb
@@ -1,6 +1,6 @@
 require 'uri'
 
-class Page
+class Crawl::Page
   include Comparable
 
   attr_reader :register, :url, :source, :error

--- a/spec/engine_spec.rb
+++ b/spec/engine_spec.rb
@@ -1,0 +1,43 @@
+RSpec.describe Crawl::Engine do
+  describe 'run' do
+    context 'given a website' do
+      let(:options) {
+        {
+          domain: 'https://www.example.com',
+        }.merge(authentication)
+      }
+
+      context 'with a jwt token' do
+        let(:authentication) {
+          {
+            auth_token: 'my_token'
+          }
+        }
+        it 'makes a request using the provided token' do
+          stub_request(:get, "https://www.example.com/").
+            with(:headers => {'Authorization'=> 'my_token'}).
+            to_return(:status => 200, :body => "", :headers => {})
+          crawler = described_class.new(options)
+          crawler.run
+        end
+      end
+
+      context 'with a username and password' do
+        let(:authentication) {
+          {
+            username: 'user',
+            password: 'password'
+          }
+        }
+
+        it 'makes a request with the correct credentials' do
+          stub_request(:get, "https://www.example.com/").
+            with(:headers => {'Authorization'=>['user', 'password']}).
+            to_return(:status => 200, :body => "", :headers => {})
+          crawler = described_class.new(options)
+          crawler.run
+        end
+      end
+    end
+  end
+end

--- a/spec/page_spec.rb
+++ b/spec/page_spec.rb
@@ -1,13 +1,13 @@
 require './lib/crawl/page'
 
-RSpec.describe Page do
+RSpec.describe Crawl::Page do
   describe "#relative_url" do
-    specify { expect(Page.new(:register, "/", "/").relative_url).to eq "/" }
-    specify { expect(Page.new(:register, "./", "/").relative_url).to eq "/" }
-    specify { expect(Page.new(:register, "page.html", "").relative_url).to eq "/page.html" }
-    specify { expect(Page.new(:register, "/interview", "/").relative_url).to eq "/interview" }
-    specify { expect(Page.new(:register, "overview.html", "/").relative_url).to eq "/overview.html" }
-    specify { expect(Page.new(:register, "post-5.html", "/posts/index.html").relative_url).to eq "/posts/post-5.html" }
-    specify { expect(Page.new(:register, "https://staging.alphasights.com/careers/meet-us", "/posts/foo").relative_url).to eq "/careers/meet-us" }
+    specify { expect(described_class.new(:register, "/", "/").relative_url).to eq "/" }
+    specify { expect(described_class.new(:register, "./", "/").relative_url).to eq "/" }
+    specify { expect(described_class.new(:register, "page.html", "").relative_url).to eq "/page.html" }
+    specify { expect(described_class.new(:register, "/interview", "/").relative_url).to eq "/interview" }
+    specify { expect(described_class.new(:register, "overview.html", "/").relative_url).to eq "/overview.html" }
+    specify { expect(described_class.new(:register, "post-5.html", "/posts/index.html").relative_url).to eq "/posts/post-5.html" }
+    specify { expect(described_class.new(:register, "https://staging.alphasights.com/careers/meet-us", "/posts/foo").relative_url).to eq "/careers/meet-us" }
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,7 @@
+require './lib/crawl'
+require 'pry'
+require 'webmock/rspec'
+
 RSpec.configure do |config|
   config.expect_with :rspec do |expectations|
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true


### PR DESCRIPTION
In order to support websites that use alternative authentication as opposed to
using a username/password in the URL, I've added the option to pass in a
token to be used as the value of the 'Authorization' header.

While looking at the code I noticed we did not namespace one of the
classes (`Page`), and added a spec for the `Crawl::Engine`. We are also
introducing webmock to be able to fake the whole process and make sure
we are hitting the website with the correct headers.